### PR TITLE
Add a spec to ensure our DB config patch is in place

### DIFF
--- a/vmdb/config/environments/patches/database_configuration.rb
+++ b/vmdb/config/environments/patches/database_configuration.rb
@@ -2,16 +2,8 @@
 # mode for security purposes.  Also, adds support to handle encrypted
 # password fields as strings without ERB.
 #
-# The original implementation is as follows:
-#
-#    def database_configuration
-#      require 'erb'
-#      YAML::load(ERB.new(IO.read(paths["config/database"].first)).result)
-#    end
 require 'rails/application/configuration'
 Rails::Application::Configuration.module_eval do
-  # sorry for the multi line {}
-  # block needs to be associated with module not prepend
   prepend Module.new {
     def database_configuration
       path = paths["config/database"].existent.first

--- a/vmdb/spec/lib/extensions/database_configuration_spec.rb
+++ b/vmdb/spec/lib/extensions/database_configuration_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe "DatabaseConfiguration patch" do
+  before(:each) do
+    Rails.stub(:env => ActiveSupport::StringInquirer.new("production"))
+
+    @app = Vmdb::Application.new
+    @app.config.paths["config/database"] = "does/not/exist" # ignore real database.yml
+  end
+
+  context "ERB in the template" do
+    before(:each) do
+      @tempfile = Tempfile.new('yml').tap do |f|
+        f.write database_config
+        f.close
+      end
+      @app.config.paths["config/database"].unshift @tempfile.path
+    end
+
+    let(:database_config) { "---\nvalue: <%= 1 %>\n" }
+
+    it "doesn't execute" do
+      expect(@app.config.database_configuration).to eq('value' => '<%= 1 %>')
+    end
+  end
+
+  context "when DATABASE_URL is set" do
+    around(:each) do |example|
+      old_env, ENV['DATABASE_URL'] = ENV['DATABASE_URL'], 'postgres://'
+      example.run
+      ENV['DATABASE_URL'] = old_env
+    end
+
+    it "ignores a missing file" do
+      expect(@app.config.database_configuration).to eq({})
+    end
+  end
+
+  context "with no source of configuration" do
+    it "explains the problem" do
+      expect { @app.config.database_configuration }.to raise_error(/Could not load database configuration/)
+    end
+  end
+end


### PR DESCRIPTION
* Protect against this patch going missing (e.g., the `{`/`}` vs `do`/`end` problem)
* Prove the `DATABASE_URL` behaviour (i.e., the point of the current change)
* Relatedly, also prove we're now giving the nicer error message when the config really is MIA

... and remove some comments: the "original implementation" is a lie (or at least outdated); and the style apology is no longer necessary, because we have a spec for it. (And it's making me look bad for not having a similar comment :wink:)